### PR TITLE
Fix service provider class path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 # Changelog
 
 All notable changes to `laravel-power-relations` will be documented in this file.
+
+## Unreleased
+
+### Fixed
+- Missing Class Path for ServiceProvider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `laravel-power-relations` will be documented in this file.
+All notable changes to `laravel-custom-relations` will be documented in this file.
 
 ## Unreleased
 

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
     "extra": {
         "laravel": {
             "providers": [
-              "LaravelCustomRelationsServiceProvider"
+              "Clickbar\\LaravelCustomRelations\\LaravelCustomRelationsServiceProvider"
             ]
         }
     },


### PR DESCRIPTION
The ServieProvider Class in the composer.json was missing its classpath.
This caused a crash in package discovery.

This PR adds the missing class path